### PR TITLE
Add option to hide time stamps

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -387,7 +387,7 @@ class MainActivity :
 		weekView.firstDayOfWeek = preferences.defaultPrefs.getStringSet("preference_week_custom_range", emptySet())?.map { MaterialDayPicker.Weekday.valueOf(it) }?.min()?.ordinal
 				?: DateTimeFormat.forPattern("E").withLocale(Locale.ENGLISH).parseDateTime((profileUser.timeGrid.days[0].day)).dayOfWeek
 
-		if (PreferenceUtils.getPrefBool(preferences, "preference_timetable_hide_time_stamps")) weekView.timeColumnTextColor = Color.TRANSPARENT
+        weekView.timeColumnVisibility = !PreferenceUtils.getPrefBool(preferences, "preference_timetable_hide_time_stamps")
 
 		weekView.columnGap = ConversionUtils.dpToPx(PreferenceUtils.getPrefInt(preferences, "preference_timetable_item_padding").toFloat(), this).toInt()
 		weekView.overlappingEventGap = ConversionUtils.dpToPx(PreferenceUtils.getPrefInt(preferences, "preference_timetable_item_padding_overlap").toFloat(), this).toInt()

--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -387,6 +387,8 @@ class MainActivity :
 		weekView.firstDayOfWeek = preferences.defaultPrefs.getStringSet("preference_week_custom_range", emptySet())?.map { MaterialDayPicker.Weekday.valueOf(it) }?.min()?.ordinal
 				?: DateTimeFormat.forPattern("E").withLocale(Locale.ENGLISH).parseDateTime((profileUser.timeGrid.days[0].day)).dayOfWeek
 
+		if (PreferenceUtils.getPrefBool(preferences, "preference_timetable_hide_time_stamps")) weekView.timeColumnTextColor = Color.TRANSPARENT
+
 		weekView.columnGap = ConversionUtils.dpToPx(PreferenceUtils.getPrefInt(preferences, "preference_timetable_item_padding").toFloat(), this).toInt()
 		weekView.overlappingEventGap = ConversionUtils.dpToPx(PreferenceUtils.getPrefInt(preferences, "preference_timetable_item_padding_overlap").toFloat(), this).toInt()
 		weekView.eventCornerRadius = ConversionUtils.dpToPx(PreferenceUtils.getPrefInt(preferences, "preference_timetable_item_corner_radius").toFloat(), this).toInt()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -199,6 +199,8 @@
 	<string name="preference_timetable_colors_reset">Farben zurücksetzen</string>
 	<string name="preference_timetable_hide_cancelled">Entfallene Stunden ausblenden</string>
 	<string name="preference_timetable_hide_cancelled_desc">Wird erst bei erneutem Laden des Stundenplans aktiv</string>
+	<string name="preference_timetable_hide_time_stamps">Zeitstempel verstecken</string>
+	<string name="preference_timetable_hide_time_stamps_desc">Zeitstempel neben dem Stundenplan verstecken</string>
 	<string name="preference_timetable_item_corner_radius">Abgerundete Ecken</string>
 	<string name="preference_timetable_item_padding">Abstand zwischen Stunden</string>
 	<string name="preference_timetable_item_padding_overlap">Abstand zwischen gleichzeitigen Stunden</string>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -8,6 +8,7 @@
 	<bool name="preference_timetable_bold_lesson_name_default">true</bool>
 	<bool name="preference_timetable_item_text_light_default">true</bool>
 	<bool name="preference_timetable_hide_cancelled_default">false</bool>
+	<bool name="preference_timetable_hide_time_stamps_default">false</bool>
 	<bool name="preference_timetable_range_index_reset_default">false</bool>
 	<bool name="preference_timetable_substitutions_irregular_default">false</bool>
 	<bool name="preference_notifications_before_first_default">false</bool>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,8 @@
 	<string name="preference_timetable_colors_reset">Reset colors</string>
 	<string name="preference_timetable_hide_cancelled">Hide cancelled lessons</string>
 	<string name="preference_timetable_hide_cancelled_desc">You need to reload the timetable after you change this setting</string>
+	<string name="preference_timetable_hide_time_stamps">Hide time stamps</string>
+	<string name="preference_timetable_hide_time_stamps_desc">Hide the time stamps next to the timetable</string>
 	<string name="preference_timetable_item_corner_radius">Item corner radius</string>
 	<string name="preference_timetable_item_padding">Item padding</string>
 	<string name="preference_timetable_item_padding_overlap">Overlapping item padding</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -185,6 +185,12 @@
 			android:title="@string/preference_timetable_personal_timetable" />
 
 		<CheckBoxPreference
+			android:defaultValue="@bool/preference_timetable_hide_time_stamps_default"
+			android:key="preference_timetable_hide_time_stamps"
+			android:summary="@string/preference_timetable_hide_time_stamps_desc"
+			android:title="@string/preference_timetable_hide_time_stamps" />
+
+		<CheckBoxPreference
 			android:defaultValue="@bool/preference_timetable_hide_cancelled_default"
 			android:key="preference_timetable_hide_cancelled"
 			android:summary="@string/preference_timetable_hide_cancelled_desc"

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
@@ -45,6 +45,12 @@ class WeekView<T>(
 
 	private val eventChipsProvider: EventChipProvider<T>
 
+	var timeColumnTextColor: Int
+		get() = config.timeColumnTextColor
+		set(timeColumnTextColor) {
+			config.timeColumnTextColor = timeColumnTextColor
+		}
+
 	var hourIndexOffset: Int
 		get() = config.hourIndexOffset
 		set(hourIndexOffset) {

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
@@ -45,10 +45,10 @@ class WeekView<T>(
 
 	private val eventChipsProvider: EventChipProvider<T>
 
-	var timeColumnTextColor: Int
-		get() = config.timeColumnTextColor
-		set(timeColumnTextColor) {
-			config.timeColumnTextColor = timeColumnTextColor
+	var timeColumnVisibility: Boolean
+		get() = config.timeColumnVisibility
+		set(timeColumnVisibility) {
+			config.timeColumnVisibility = timeColumnVisibility
 		}
 
 	var hourIndexOffset: Int

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewConfig.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewConfig.kt
@@ -25,6 +25,11 @@ class WeekViewConfig(context: Context, attrs: AttributeSet?) {
 	var showFirstDayOfWeekFirst: Boolean
 
 	// Time column
+	var timeColumnVisibility: Boolean = true
+		set(value) {
+			field = value
+			drawConfig.timeTextVisibility = value
+		}
 	var timeColumnTextColor: Int = 0
 		set(value) {
 			field = value

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewDrawConfig.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewDrawConfig.kt
@@ -16,6 +16,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 class WeekViewDrawConfig(context: Context) {
+	var timeTextVisibility: Boolean = true
 	val timeTextTopPaint: TextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
 	val timeTextBottomPaint: TextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
 	val timeCaptionPaint: TextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/drawers/TimeColumnDrawer.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/drawers/TimeColumnDrawer.kt
@@ -39,12 +39,14 @@ class TimeColumnDrawer(private val config: WeekViewConfig) : BaseDrawer {
 				val bottomCoordinate = top - config.hourSeparatorStrokeWidth - config.timeColumnPadding / 2
 				val topCoordinate = top - (hourTop - lastHourTop) - config.hourSeparatorStrokeWidth - config.timeColumnPadding / 2
 
-				if (i % 2 == 0) {
-					if (config.hourLines[i + 1] - config.hourLines[i] > 30)
-						canvas.drawText(time, config.timeColumnPadding.toFloat(), top + drawConfig.timeTextHeight + config.timeColumnPadding / 2, drawConfig.timeTextTopPaint)
-				} else
-					if (config.hourLines[i] - config.hourLines[i - 1] > 30)
-						canvas.drawText(time, config.timeColumnPadding + drawConfig.timeTextWidth, bottomCoordinate, drawConfig.timeTextBottomPaint)
+				if (drawConfig.timeTextVisibility) {
+					if (i % 2 == 0) {
+						if (config.hourLines[i + 1] - config.hourLines[i] > 30)
+							canvas.drawText(time, config.timeColumnPadding.toFloat(), top + drawConfig.timeTextHeight + config.timeColumnPadding / 2, drawConfig.timeTextTopPaint)
+					} else
+						if (config.hourLines[i] - config.hourLines[i - 1] > 30)
+							canvas.drawText(time, config.timeColumnPadding + drawConfig.timeTextWidth, bottomCoordinate, drawConfig.timeTextBottomPaint)
+				}
 
 				if (i % 2 == 1)
 					canvas.drawText((i / 2 + 1 + config.hourIndexOffset).toString(), config.timeColumnPadding + drawConfig.timeTextWidth / 2, topCoordinate + (bottomCoordinate - topCoordinate + drawConfig.timeCaptionHeight + config.timeColumnPadding) / 2, drawConfig.timeCaptionPaint)


### PR DESCRIPTION
Adds an option in the settings to hide the time stamps next to the timetable.
This is similar to the "Use Time Grid" option in the original Untis app.

<details>
<summary>Screenshots</summary>

|Off|On|
|---|---|
| ![Screenshot_1580143915](https://user-images.githubusercontent.com/36272047/73195541-53e46700-412e-11ea-8b64-4b5ace98a259.png) | ![Screenshot_1580143900](https://user-images.githubusercontent.com/36272047/73195546-56df5780-412e-11ea-93bc-907ec9e769f1.png) |

</details>