### PR TITLE
Adjust dialog corner radius

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/adapters/infocenter/MessageAdapter.kt
+++ b/app/src/main/java/com/sapuseven/untis/adapters/infocenter/MessageAdapter.kt
@@ -1,6 +1,5 @@
 package com.sapuseven.untis.adapters.infocenter
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -12,7 +11,9 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.sapuseven.untis.R
+import com.sapuseven.untis.models.UntisAttachment
 import com.sapuseven.untis.models.UntisMessage
 
 class MessageAdapter(
@@ -29,6 +30,12 @@ class MessageAdapter(
 	override fun onBindViewHolder(holder: ViewHolder, position: Int) {
 		val message = messageList[position]
 
+		message.attachments = listOf(
+				UntisAttachment(1, "Name 1", ""),
+				UntisAttachment(2, "Name 2", ""),
+				UntisAttachment(3, "Name 3", "")
+		)
+
 		var attachmentTitles: Array<CharSequence> = arrayOf()
 		var attachmentURLs: Array<String> = arrayOf()
 		message.attachments.forEach {
@@ -40,7 +47,7 @@ class MessageAdapter(
 		holder.tvBody.text = HtmlCompat.fromHtml(message.body, HtmlCompat.FROM_HTML_MODE_COMPACT)
 		holder.tvBody.movementMethod = LinkMovementMethod.getInstance()
 		holder.btnAttachments.setOnClickListener {
-			AlertDialog.Builder(context)
+			MaterialAlertDialogBuilder(context)
 					.setTitle(R.string.infocenter_messages_attachments)
 					.setItems(attachmentTitles) { _, which ->
 						context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(attachmentURLs[which])))

--- a/app/src/main/java/com/sapuseven/untis/adapters/infocenter/MessageAdapter.kt
+++ b/app/src/main/java/com/sapuseven/untis/adapters/infocenter/MessageAdapter.kt
@@ -30,12 +30,6 @@ class MessageAdapter(
 	override fun onBindViewHolder(holder: ViewHolder, position: Int) {
 		val message = messageList[position]
 
-		message.attachments = listOf(
-				UntisAttachment(1, "Name 1", ""),
-				UntisAttachment(2, "Name 2", ""),
-				UntisAttachment(3, "Name 3", "")
-		)
-
 		var attachmentTitles: Array<CharSequence> = arrayOf()
 		var attachmentURLs: Array<String> = arrayOf()
 		message.attachments.forEach {

--- a/app/src/main/java/com/sapuseven/untis/dialogs/ElementPickerDialog.kt
+++ b/app/src/main/java/com/sapuseven/untis/dialogs/ElementPickerDialog.kt
@@ -17,10 +17,10 @@ import android.widget.GridView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.ColorInt
-import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.sapuseven.untis.R
@@ -63,7 +63,7 @@ class ElementPickerDialog : DialogFragment() {
 
 	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 		return activity?.let { activity ->
-			val builder = AlertDialog.Builder(activity)
+			val builder = MaterialAlertDialogBuilder(activity)
 
 			builder.setView(generateView(activity))
 

--- a/app/src/main/java/com/sapuseven/untis/dialogs/TimetableItemDetailsDialog.kt
+++ b/app/src/main/java/com/sapuseven/untis/dialogs/TimetableItemDetailsDialog.kt
@@ -10,9 +10,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.sapuseven.untis.R
 import com.sapuseven.untis.data.timetable.TimegridItem
 import com.sapuseven.untis.helpers.ConversionUtils
@@ -54,7 +54,7 @@ class TimetableItemDetailsDialog : DialogFragment() {
 
 	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 		return activity?.let { activity ->
-			return AlertDialog.Builder(activity).apply {
+			return MaterialAlertDialogBuilder(activity).apply {
 				safeLet(item, timetableDatabaseInterface) { item, timetableDatabaseInterface ->
 					setView(generateView(activity, item, timetableDatabaseInterface))
 				} ?: run {

--- a/app/src/main/java/com/sapuseven/untis/dialogs/WeekRangePickerPreferenceDialog.kt
+++ b/app/src/main/java/com/sapuseven/untis/dialogs/WeekRangePickerPreferenceDialog.kt
@@ -1,13 +1,14 @@
 package com.sapuseven.untis.dialogs
 
+import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AlertDialog
 import androidx.preference.PreferenceDialogFragmentCompat
 import ca.antonious.materialdaypicker.MaterialDayPicker
 import ca.antonious.materialdaypicker.SelectionMode
 import ca.antonious.materialdaypicker.SelectionState
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.sapuseven.untis.R
 import com.sapuseven.untis.preferences.WeekRangePickerPreference
 
@@ -35,20 +36,26 @@ class WeekRangePickerPreferenceDialog(private val onCloseListener: ((positiveRes
 		return root
 	}
 
-	override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
-		super.onPrepareDialogBuilder(builder)
-		builder.setNeutralButton(R.string.all_reset) { dialog, _ ->
-			preference.persistStringSet(emptySet())
-			onCloseListener?.invoke(true, 0)
-			dialog.dismiss()
-		}
-	}
-
 	override fun onDialogClosed(positiveResult: Boolean) {
 		if (positiveResult) preference.persistStringSet(picker.selectedDays.map { it.name }.toSet())
 		(preference as? WeekRangePickerPreference)?.refreshSummary()
 
 		onCloseListener?.invoke(positiveResult, picker.selectedDays.size)
+	}
+
+	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+		val builder = MaterialAlertDialogBuilder(requireContext())
+				.setTitle(preference.dialogTitle)
+				.setView(onCreateDialogView(context))
+				.setPositiveButton(preference.positiveButtonText, this)
+				.setNegativeButton(preference.negativeButtonText, this)
+				.setNeutralButton(R.string.all_reset) { dialog, _ ->
+					preference.persistStringSet(emptySet())
+					onCloseListener?.invoke(true, 0)
+					dialog.dismiss()
+				}
+
+		return builder.create()
 	}
 
 	class RangeSelectionMode(private val materialDayPicker: MaterialDayPicker) : SelectionMode {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
 	<dimen name="margin_listitem_text_vertical">12dp</dimen>
 	<dimen name="margin_login_input">8dp</dimen>
 	<dimen name="margin_login_pleaselogin_top">24dp</dimen>
+	<dimen name="radius_dialog_corner_rounded">8dp</dimen>
 	<dimen name="size_header_icon">48dp</dimen>
 	<dimen name="size_listitem_icon">24dp</dimen>
 	<dimen name="textsize_header_line1">18sp</dimen>
@@ -13,6 +14,5 @@
 	<dimen name="textsize_listitem_line2">14sp</dimen>
 	<dimen name="textsize_listitem_overline">10sp</dimen>
 	<dimen name="textsize_login_welcome">36sp</dimen>
-
 	<dimen name="width_main_leftsidebar">38dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
 		<item name="colorDivider">@color/colorDivider</item>
 		<item name="colorOnPrimary">@color/white</item>
 		<item name="actionBarStyle">@style/Widget.MaterialComponents.ActionBar.Primary</item>
+		<item name="dialogCornerRadius">8dp</item>
 		<item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
 	</style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,9 @@
 		<item name="colorOnPrimary">@color/white</item>
 		<item name="actionBarStyle">@style/Widget.MaterialComponents.ActionBar.Primary</item>
 		<item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialAlertDialog.Rounded</item>
+		<item name="android:dialogTheme">@style/ThemeOverlay.MaterialAlertDialog.Rounded</item>
+		<item name="android:alertDialogTheme">@style/ThemeOverlay.MaterialAlertDialog.Rounded</item>
+		<item name="dialogCornerRadius">@dimen/radius_dialog_corner_rounded</item>
 		<item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
 	</style>
 
@@ -21,7 +24,7 @@
 	</style>
 
 	<style name="ShapeAppearance.MaterialAlertDialog.Rounded" parent="">
-		<item name="cornerSize">8dp</item>
+		<item name="cornerSize">@dimen/radius_dialog_corner_rounded</item>
 	</style>
 
 	<style name="AppTheme.NoActionBar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,8 +8,20 @@
 		<item name="colorDivider">@color/colorDivider</item>
 		<item name="colorOnPrimary">@color/white</item>
 		<item name="actionBarStyle">@style/Widget.MaterialComponents.ActionBar.Primary</item>
-		<item name="dialogCornerRadius">8dp</item>
+		<item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialAlertDialog.Rounded</item>
 		<item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
+	</style>
+
+	<style name="ThemeOverlay.MaterialAlertDialog.Rounded" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+		<item name="alertDialogStyle">@style/MaterialAlertDialog.Rounded</item>
+	</style>
+
+	<style name="MaterialAlertDialog.Rounded" parent="MaterialAlertDialog.MaterialComponents">
+		<item name="shapeAppearance">@style/ShapeAppearance.MaterialAlertDialog.Rounded</item>
+	</style>
+
+	<style name="ShapeAppearance.MaterialAlertDialog.Rounded" parent="">
+		<item name="cornerSize">8dp</item>
 	</style>
 
 	<style name="AppTheme.NoActionBar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,6 +17,7 @@
 
 	<style name="ThemeOverlay.MaterialAlertDialog.Rounded" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
 		<item name="alertDialogStyle">@style/MaterialAlertDialog.Rounded</item>
+		<item name="materialAlertDialogTitleTextStyle">@style/MaterialDialog.MaterialComponents.Title.Text</item>
 	</style>
 
 	<style name="MaterialAlertDialog.Rounded" parent="MaterialAlertDialog.MaterialComponents">
@@ -25,6 +26,16 @@
 
 	<style name="ShapeAppearance.MaterialAlertDialog.Rounded" parent="">
 		<item name="cornerSize">@dimen/radius_dialog_corner_rounded</item>
+	</style>
+
+	<style name="MaterialDialog.MaterialComponents.Title.Text" parent="@style/MaterialAlertDialog.MaterialComponents.Title.Text">
+		<item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Title</item>
+	</style>
+	
+	<style name="TextAppearance.MaterialComponents.Title" parent="">
+		<item name="android:textSize">20sp</item>
+		<item name="android:textStyle">bold</item>
+		<item name="android:textColor">?android:attr/textColorPrimary</item>
 	</style>
 
 	<style name="AppTheme.NoActionBar">


### PR DESCRIPTION
Adjusts the dialogs' corner radius to fit the new dialog styles of newer Android versions.

The attachments dialog for the messages does heavily refuse to inherit the dialog corner radius for some reason.