### PR TITLE
Use new MaterialDatePickerDialog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 	implementation "com.github.kittinunf.fuel:fuel:2.2.3"
 	implementation "com.github.kittinunf.fuel:fuel-coroutines:2.2.3"
 	implementation "joda-time:joda-time:2.10.6"
-	implementation 'com.google.android.material:material:1.2.0-alpha04' //Newer versions will break DatePickerDialog
+	implementation 'com.google.android.material:material:1.3.0-alpha03'
 	implementation 'com.jaredrummler:colorpicker-compat:1.0.5'
 	implementation 'com.github.cesarferreira:MaterialComponent.Banner:0.13.0'
 	implementation 'com.budiyev.android:code-scanner:2.1.0'

--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -126,7 +126,6 @@ class MainActivity :
 	private var profileId: Long = -1
 	private val weeklyTimetableItems: MutableMap<Int, WeeklyTimetableItems?> = mutableMapOf()
 	private var displayedElement: PeriodElement? = null
-	private var lastPickedDate: DateTime? = null
 	private var proxyHost: String? = null
 	private var profileUpdateDialog: AlertDialog? = null
 	private var currentWeekIndex = 0
@@ -991,23 +990,12 @@ class MainActivity :
 	}
 
 	override fun onCornerClick() {
-		val fragment = DatePickerDialog()
+		val fragment = DatePickerDialog().createFragment()
 
-		lastPickedDate?.let {
-			val args = Bundle()
-			args.putInt("year", it.year)
-			args.putInt("month", it.monthOfYear)
-			args.putInt("day", it.dayOfMonth)
-			fragment.arguments = args
+		fragment.addOnPositiveButtonClickListener {
+			weekView.goToDate(DateTime(it))
 		}
-		fragment.dateSetListener = android.app.DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
-			DateTime().withDate(year, month + 1, dayOfMonth).let {
-				// +1 compensates for conversion from Calendar to DateTime
-				weekView.goToDate(it)
-				lastPickedDate = it
-			}
-		}
-		fragment.show(supportFragmentManager, "datePicker")
+		fragment.show(supportFragmentManager, fragment.toString())
 	}
 
 	override fun onCornerLongClick() = weekView.goToToday()

--- a/app/src/main/java/com/sapuseven/untis/dialogs/DatePickerDialog.kt
+++ b/app/src/main/java/com/sapuseven/untis/dialogs/DatePickerDialog.kt
@@ -1,28 +1,17 @@
 package com.sapuseven.untis.dialogs
 
-import android.app.Dialog
-import android.os.Bundle
-import androidx.fragment.app.DialogFragment
-import com.sapuseven.untis.R
-import org.joda.time.DateTime
+import com.google.android.material.datepicker.MaterialDatePicker
 
-class DatePickerDialog : DialogFragment() {
-	var dateSetListener: android.app.DatePickerDialog.OnDateSetListener? = null
+class DatePickerDialog() {
 
-	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-		val dialog: android.app.DatePickerDialog = arguments?.let {
-			val year = it.getInt("year")
-			val month = it.getInt("month")
-			val day = it.getInt("day")
-			android.app.DatePickerDialog(requireContext(), dateSetListener, year, month - 1, day)
-		} ?: run {
-			val now = DateTime.now()
-			android.app.DatePickerDialog(requireContext(), dateSetListener, now.year, now.monthOfYear - 1, now.dayOfMonth)
-		}
+	internal fun createFragment(): MaterialDatePicker<Long> {
+		return  MaterialDatePicker.Builder.datePicker().setSelection(MaterialDatePicker.todayInUtcMilliseconds()).build()
+	}
+
+	/*	TODO: Add this button
 		dialog.setButton(android.app.DatePickerDialog.BUTTON_NEUTRAL, getString(R.string.all_dialog_datepicker_button_today)) { _, _ ->
 			val dateTime = DateTime.now()
 			dateSetListener?.onDateSet(dialog.datePicker, dateTime.year, dateTime.monthOfYear - 1, dateTime.dayOfMonth)
 		}
-		return dialog
-	}
+	}*/
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,6 +15,7 @@
 		<item name="android:alertDialogTheme">@style/ThemeOverlay.MaterialAlertDialog.Rounded</item>
 		<item name="dialogCornerRadius">@dimen/radius_dialog_corner_rounded</item>
 		<item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
+		<item name="materialCalendarTheme">@style/ThemeMaterialCalendar</item>
 	</style>
 
 	<style name="ThemeOverlay.MaterialAlertDialog.Rounded" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
@@ -170,5 +171,9 @@
 		<item name="android:backgroundTint">?attr/colorPrimary</item>
 		<item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
 		<item name="android:gravity">center</item>
+	</style>
+	
+	<style name="ThemeMaterialCalendar" parent="ThemeOverlay.MaterialComponents.MaterialCalendar">
+		<item name="colorPrimary">?attr/colorAccent</item>
 	</style>
 </resources>


### PR DESCRIPTION
Uses the [new component](https://material.io/components/date-pickers). Unfortunately, there seems to be no way to manipulate the view to add a "today" button.