### PR TITLE
Add delay to auto-mute

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/receivers/AutoMuteSetup.kt
+++ b/app/src/main/java/com/sapuseven/untis/receivers/AutoMuteSetup.kt
@@ -40,13 +40,15 @@ class AutoMuteSetup : LessonEventSetup() {
 				alarmManager.setExact(AlarmManager.RTC_WAKEUP, item.startDateTime.millis, pendingMuteIntent)
 				Log.d("AutoMuteSetup", "${item.periodData.getShortTitle()} mute scheduled for ${item.startDateTime}")
 
-				if (item.endDateTime == it.second?.startDateTime) return@forEach // No break exists, don't unmute
+				val delay = PreferenceUtils.getPrefInt(preferenceManager, "preference_automute_unmute_delay").toLong()
+				val endDateTimeWithDelay = item.endDateTime.withDurationAdded(delay, 1000 * 60)
+				if (it.second != null && endDateTimeWithDelay >= it.second!!.startDateTime) return@forEach // No break exists, don't unmute
 				val unmuteIntent = Intent(context, AutoMuteReceiver::class.java)
 						.putExtra(EXTRA_INT_ID, id)
 						.putExtra(EXTRA_BOOLEAN_MUTE, false)
-				val pendingUnmuteIntent = PendingIntent.getBroadcast(context, item.endDateTime.millisOfDay, unmuteIntent, 0)
-				alarmManager.setExact(AlarmManager.RTC_WAKEUP, item.endDateTime.millis, pendingUnmuteIntent)
-				Log.d("AutoMuteSetup", "${item.periodData.getShortTitle()} unmute scheduled for ${item.endDateTime}")
+				val pendingUnmuteIntent = PendingIntent.getBroadcast(context, endDateTimeWithDelay.millisOfDay, unmuteIntent, 0)
+				alarmManager.setExact(AlarmManager.RTC_WAKEUP, endDateTimeWithDelay.millis, pendingUnmuteIntent)
+				Log.d("AutoMuteSetup", "${item.periodData.getShortTitle()} unmute scheduled for $endDateTimeWithDelay")
 			}
 		}
 	}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -137,6 +137,8 @@
     <string name="preference_automute_enable">Automatisches Stummschalten</string>
     <string name="preference_automute_enable_summary">Aktiviert während jeder Stunde automatisch den „Bitte nicht stören“-Modus</string>
     <string name="preference_automute_cancelled_lessons">Auch in entfallenen Stunden stumm schalten</string>
+    <string name="preference_automute_unmute_delay_summary">Verzögerung in Minuten, nach der die Stummschaltung aufgehoben werden soll</string>
+    <string name="preference_automute_unmute_delay">Verzögerung</string>
     <string name="preference_background_cancelled">Entfallene Stunden</string>
     <string name="preference_background_cancelled_past">Vergangene entfallene Stunden</string>
     <string name="preference_background_exam">Stunden mit Tests</string>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -38,6 +38,7 @@
 	<integer name="preference_timetable_item_corner_radius_default">4</integer>
 	<integer name="preference_timetable_lesson_name_font_size_default">14</integer>
 	<integer name="preference_timetable_lesson_info_font_size_default">10</integer>
+	<integer name="preference_automute_unmute_delay_default">0</integer>
 
 	<string name="preference_theme_default">default</string>
 	<string name="preference_dark_theme_default">off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
 	<string name="preference_automute_cancelled_lessons">Also mute in cancelled lessons</string>
 	<string name="preference_automute_enable">Enable auto-mute</string>
 	<string name="preference_automute_enable_summary">Automatically turns on Do Not Disturb during lessons</string>
+	<string name="preference_automute_unmute_delay_summary">Delay in minutes after which auto-mute should unmute after lesson</string>
+	<string name="preference_automute_unmute_delay">Unmute delay</string>
 	<string name="preference_background_cancelled">Cancelled lessons</string>
 	<string name="preference_background_cancelled_past">Past cancelled lessons</string>
 	<string name="preference_background_exam">Lessons with tests</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,6 +50,14 @@
 				android:dependency="preference_automute_enable"
 				android:key="preference_automute_cancelled_lessons"
 				android:title="@string/preference_automute_cancelled_lessons" />
+			<SeekBarPreference
+				android:defaultValue="@integer/preference_automute_unmute_delay_default"
+				android:dependency="preference_automute_enable"
+				android:key="preference_automute_unmute_delay"
+				android:max="10"
+				android:summary="@string/preference_automute_unmute_delay_summary"
+				android:title="@string/preference_automute_unmute_delay"
+				app:showSeekBarValue="true" />
 		</PreferenceCategory>
 
 		<!-- TODO: Extract string resources -->


### PR DESCRIPTION
My school has configured a 5 minute break between some lessons which nobody sticks to. Without a configurable unmute delay my phone would unmute in this break making noise.