### PR TITLE
Use labels for hours provided by Untis API

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -559,6 +559,7 @@ class MainActivity :
 
 	private fun setupHours() {
 		val lines = MutableList(0) { return@MutableList 0 }
+		val labels = MutableList(0) { return@MutableList "" }
 		val range = RangePreference.convertToPair(PreferenceUtils.getPrefString(preferences, "preference_timetable_range", null))
 
 		profileUser.timeGrid.days.maxBy { it.units.size }?.units?.forEachIndexed { index, hour ->
@@ -575,12 +576,13 @@ class MainActivity :
 
 			lines.add(startTimeInt)
 			lines.add(endTimeInt)
+			labels.add(hour.label)
 		}
 
 		if (!PreferenceUtils.getPrefBool(preferences, "preference_timetable_range_index_reset"))
 			weekView.hourIndexOffset = (range?.first ?: 1) - 1
 		weekView.hourLines = lines.toIntArray()
-
+		weekView.hourLabels = labels.toTypedArray()
 		weekView.startTime = lines.first()
 		weekView.endTime = lines.last() + 30 // TODO: Don't hard-code this offset
 	}

--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -561,7 +561,6 @@ class MainActivity :
 		val lines = MutableList(0) { return@MutableList 0 }
 		val labels = MutableList(0) { return@MutableList "" }
 		val range = RangePreference.convertToPair(PreferenceUtils.getPrefString(preferences, "preference_timetable_range", null))
-
 		profileUser.timeGrid.days.maxBy { it.units.size }?.units?.forEachIndexed { index, hour ->
 			if (range?.let { index < it.first - 1 || index >= it.second } == true) return@forEachIndexed
 
@@ -582,7 +581,10 @@ class MainActivity :
 		if (!PreferenceUtils.getPrefBool(preferences, "preference_timetable_range_index_reset"))
 			weekView.hourIndexOffset = (range?.first ?: 1) - 1
 		weekView.hourLines = lines.toIntArray()
-		weekView.hourLabels = labels.toTypedArray()
+		weekView.hourLabels = labels.toTypedArray().let { hourLabelArray ->
+			if(hourLabelArray.joinToString("")=="") IntArray(labels.size, fun(idx:Int):Int{return idx+1}).map{it.toString()}.toTypedArray()
+			else hourLabelArray
+		}
 		weekView.startTime = lines.first()
 		weekView.endTime = lines.last() + 30 // TODO: Don't hard-code this offset
 	}

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/WeekView.kt
@@ -217,6 +217,13 @@ class WeekView<T>(
 			invalidate()
 		}
 
+	var hourLabels: Array<String>
+		get() = config.hourLabels
+		set(labels) {
+			config.hourLabels = labels
+			invalidate()
+		}
+
 	var startTime: Int
 		get() = config.startTime
 		set(startTime) {

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewConfig.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/config/WeekViewConfig.kt
@@ -221,7 +221,7 @@ class WeekViewConfig(context: Context, attrs: AttributeSet?) {
 			drawConfig.hourSeparatorPaint.color = value
 		}
 	var hourSeparatorStrokeWidth: Float
-        get() = drawConfig.hourSeparatorPaint.strokeWidth
+		get() = drawConfig.hourSeparatorPaint.strokeWidth
 		set(value) {
 			drawConfig.hourSeparatorPaint.strokeWidth = value
 		}
@@ -234,7 +234,7 @@ class WeekViewConfig(context: Context, attrs: AttributeSet?) {
 			drawConfig.daySeparatorPaint.color = value
 		}
 	var daySeparatorStrokeWidth: Float
-        get() = drawConfig.daySeparatorPaint.strokeWidth
+		get() = drawConfig.daySeparatorPaint.strokeWidth
 		set(value) {
 			drawConfig.daySeparatorPaint.strokeWidth = value
 		}
@@ -254,7 +254,7 @@ class WeekViewConfig(context: Context, attrs: AttributeSet?) {
 	var startTime: Int = 0 // in minutes
 	var endTime: Int = 0 // in minutes
 	var hourLines: IntArray = IntArray(0) // in minutes
-
+	lateinit var hourLabels: Array<String>
 	// Calculated values
 
 	val timeColumnWidth: Float

--- a/weekview/src/main/java/com/sapuseven/untis/views/weekview/drawers/TimeColumnDrawer.kt
+++ b/weekview/src/main/java/com/sapuseven/untis/views/weekview/drawers/TimeColumnDrawer.kt
@@ -49,7 +49,7 @@ class TimeColumnDrawer(private val config: WeekViewConfig) : BaseDrawer {
 				}
 
 				if (i % 2 == 1)
-					canvas.drawText((i / 2 + 1 + config.hourIndexOffset).toString(), config.timeColumnPadding + drawConfig.timeTextWidth / 2, topCoordinate + (bottomCoordinate - topCoordinate + drawConfig.timeCaptionHeight + config.timeColumnPadding) / 2, drawConfig.timeCaptionPaint)
+					canvas.drawText(config.hourLabels[i / 2], config.timeColumnPadding + drawConfig.timeTextWidth / 2, topCoordinate + (bottomCoordinate - topCoordinate + drawConfig.timeCaptionHeight + config.timeColumnPadding) / 2, drawConfig.timeCaptionPaint)
 			}
 		}
 


### PR DESCRIPTION
Untis sends explicit labels for hours, f.e. if the school has a lesson "0", see #166 
This displays the labels instead of counting up from 1, if there are any

Closes #166 