### PR TITLE
Add option to allow priority events while auto-muted

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/receivers/AutoMuteReceiver.kt
+++ b/app/src/main/java/com/sapuseven/untis/receivers/AutoMuteReceiver.kt
@@ -33,11 +33,17 @@ class AutoMuteReceiver : BroadcastReceiver() {
 			if (intent.getBooleanExtra(EXTRA_BOOLEAN_MUTE, false)) {
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 					val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+					val interruptionFilter =
+						if(PreferenceUtils.getPrefBool(preferenceManager, "preference_automute_mute_priority"))
+							NotificationManager.INTERRUPTION_FILTER_NONE
+						else
+							NotificationManager.INTERRUPTION_FILTER_PRIORITY
+
 					if (!prefs.contains(PREFERENCE_KEY_INTERRUPTION_FILTER)) {
 						editor.putInt(PREFERENCE_KEY_INTERRUPTION_FILTER, notificationManager.currentInterruptionFilter)
 						Log.d("AutoMuteReceiver", "Saved interruption filter: ${notificationManager.currentInterruptionFilter}")
 					}
-					notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
+					notificationManager.setInterruptionFilter(interruptionFilter)
 				} else {
 					val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 					editor.putInt(PREFERENCE_KEY_RINGER_MODE, audioManager.ringerMode)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -138,6 +138,7 @@
     <string name="preference_automute_enable">Automatisches Stummschalten</string>
     <string name="preference_automute_enable_summary">Aktiviert während jeder Stunde automatisch den „Bitte nicht stören“-Modus</string>
     <string name="preference_automute_cancelled_lessons">Auch in entfallenen Stunden stumm schalten</string>
+    <string name="preference_automute_mute_priority">Ausnahmen für \"Bitte nicht Stören\" ignorieren</string>
     <string name="preference_automute_minimum_break_length_summary">Stummschaltung nicht aufheben, wenn die Pause kürzer als die angegebene Dauer ist (in Minuten)</string>
     <string name="preference_automute_minimum_break_length">Mindestpausendauer</string>
     <string name="preference_background_cancelled">Entfallene Stunden</string>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -19,6 +19,7 @@
 	<bool name="preference_week_snap_to_days_default">false</bool>
 	<bool name="preference_automute_enable_default">false</bool>
 	<bool name="preference_automute_cancelled_lessons_default">true</bool>
+	<bool name="preference_automute_mute_priority_default">true</bool>
 	<bool name="preference_additional_error_messages_default">false</bool>
 
 	<integer name="preference_background_regular_default">0xFFF44336</integer>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
 	<string name="preference_automute_cancelled_lessons">Also mute in cancelled lessons</string>
 	<string name="preference_automute_enable">Enable auto-mute</string>
 	<string name="preference_automute_enable_summary">Automatically turns on Do Not Disturb during lessons</string>
+	<string name="preference_automute_mute_priority">Don\'t allow priority events to ignore aute-mute</string>
 	<string name="preference_automute_minimum_break_length_summary">Don\'t unmute the device during breaks shorter than the specified length (in minutes)</string>
 	<string name="preference_automute_minimum_break_length">Minimum break length</string>
 	<string name="preference_background_cancelled">Cancelled lessons</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -50,6 +50,11 @@
 				android:dependency="preference_automute_enable"
 				android:key="preference_automute_cancelled_lessons"
 				android:title="@string/preference_automute_cancelled_lessons" />
+			<SwitchPreference
+				android:defaultValue="@bool/preference_automute_mute_priority_default"
+				android:dependency="preference_automute_enable"
+				android:key="preference_automute_mute_priority"
+				android:title="@string/preference_automute_mute_priority" />
 			<SeekBarPreference
 				android:defaultValue="@integer/preference_automute_minimum_break_length_default"
 				android:dependency="preference_automute_enable"


### PR DESCRIPTION
Add an option to use NotificationManager.INTERRUPTION_FILTER_PRIORITY instead of NotificationManager.INTERRUPTION_FILTER_NONE to allow using exceptions for "Do Not Disturb"-Mode