### PR TITLE
Add links and privacy question

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
@@ -14,7 +14,6 @@ import android.os.Bundle
 import android.provider.Settings
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -287,7 +286,7 @@ class SettingsActivity : BaseActivity(), PreferenceFragmentCompat.OnPreferenceSt
 						}
 					}
 					"preferences_contributors" -> {
-						AlertDialog.Builder(requireContext())
+						MaterialAlertDialogBuilder(requireContext())
 							.setTitle(R.string.preference_info_privacy)
 							.setMessage(R.string.preference_info_privacy_desc)
 							.setPositiveButton(android.R.string.ok) { _, _ ->
@@ -302,8 +301,11 @@ class SettingsActivity : BaseActivity(), PreferenceFragmentCompat.OnPreferenceSt
 										})
 								}
 							}
-							.setNegativeButton(android.R.string.cancel) { _, _ -> }
+							.setNegativeButton(android.R.string.cancel) { _, _ ->
+								parentFragmentManager.popBackStackImmediate()
+							}
 							.setNeutralButton(R.string.preference_info_privacy_policy) { _, _ ->
+								parentFragmentManager.popBackStackImmediate()
 								startActivity(
 									Intent(
 										Intent.ACTION_VIEW, Uri.parse(

--- a/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
@@ -14,6 +14,7 @@ import android.os.Bundle
 import android.provider.Settings
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -242,33 +243,76 @@ class SettingsActivity : BaseActivity(), PreferenceFragmentCompat.OnPreferenceSt
 						}
 					}
 					"preferences_info" -> {
-						findPreference<Preference>("preference_info_app_version")?.summary = let {
-							val pInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
-							requireContext().getString(R.string.preference_info_app_version_desc,
-									pInfo.versionName,
-									PackageInfoCompat.getLongVersionCode(pInfo)
+						findPreference<Preference>("preference_info_app_version")?.apply {
+							val pInfo =
+								requireContext().packageManager.getPackageInfo(
+									requireContext().packageName,
+									0
+								)
+							summary = requireContext().getString(
+								R.string.preference_info_app_version_desc,
+								pInfo.versionName,
+								PackageInfoCompat.getLongVersionCode(pInfo)
 							)
-						}
-
-						findPreference<Preference>("preference_info_github")?.apply {
-							summary = REPOSITORY_URL_GITHUB
 							setOnPreferenceClickListener {
-								startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL_GITHUB)))
+								startActivity(
+									Intent(
+										Intent.ACTION_VIEW,
+										Uri.parse("$REPOSITORY_URL_GITHUB/releases")
+									)
+								)
 								true
 							}
 						}
+						findPreference<Preference>("preference_info_github")?.apply {
+							summary = REPOSITORY_URL_GITHUB
+							setOnPreferenceClickListener {
+								startActivity(
+									Intent(
+										Intent.ACTION_VIEW,
+										Uri.parse(REPOSITORY_URL_GITHUB)
+									)
+								)
+								true
+							}
+						}
+						findPreference<Preference>("preference_info_license")?.setOnPreferenceClickListener {
+							startActivity(
+								Intent(
+									Intent.ACTION_VIEW,
+									Uri.parse("$REPOSITORY_URL_GITHUB/blob/master/LICENSE")
+								)
+							)
+							true
+						}
 					}
 					"preferences_contributors" -> {
-						GlobalScope.launch(Dispatchers.Main) {
-							"https://api.github.com/repos/sapuseven/betteruntis/contributors"
-									.httpGet()
-									.awaitStringResult()
-									.fold({ data ->
-										showContributorList(true, data)
-									}, {
-										showContributorList(false)
-									})
-						}
+						AlertDialog.Builder(requireContext())
+							.setTitle(R.string.preference_info_privacy)
+							.setMessage(R.string.preference_info_privacy_desc)
+							.setPositiveButton(android.R.string.ok) { _, _ ->
+								GlobalScope.launch(Dispatchers.Main) {
+									"https://api.github.com/repos/sapuseven/betteruntis/contributors"
+										.httpGet()
+										.awaitStringResult()
+										.fold({ data ->
+											showContributorList(true, data)
+										}, {
+											showContributorList(false)
+										})
+								}
+							}
+							.setNegativeButton(android.R.string.cancel) { _, _ -> }
+							.setNeutralButton(R.string.preference_info_privacy_policy) { _, _ ->
+								startActivity(
+									Intent(
+										Intent.ACTION_VIEW, Uri.parse(
+											"https://docs.github.com/en/github/site-policy/github-privacy-statement"
+										)
+									)
+								)
+							}
+							.show()
 					}
 				}
 			}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -173,6 +173,10 @@
     <string name="preference_info_contributors_desc">Eine Liste aller Mitwirkenden am Projekt</string>
     <string name="preference_info_libraries">Bibliotheken</string>
     <string name="preference_info_libraries_desc">Eine Liste aller verwendeten Software-Bibliotheken</string>
+    <string name="preference_info_license">Lizenz</string>
+    <string name="preference_info_privacy">Externe Inhalte</string>
+    <string name="preference_info_privacy_desc">Mitwirkende werden von GitHub geladen. Lesen Sie deren Datenschutzrichtlinie für weitere Informationen.</string>
+    <string name="preference_info_privacy_policy">Datenschutz-Bestimmungen</string>
     <string name="preference_marker">Zeitanzeige</string>
     <string name="preference_notifications_clear">Alle Benachrichtigungen löschen</string>
     <string name="preference_notifications_enable">Benachrichtigungen aktivieren</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,6 +189,11 @@
 	<string name="preference_info_contributors_desc">A list of the contributors</string>
 	<string name="preference_info_general">General</string>
 	<string name="preference_info_github">GitHub repository</string>
+	<string name="preference_info_privacy">External Content</string>
+	<string name="preference_info_privacy_desc">Contributors are loaded from GitHub. Read their privacy policy for further information.</string>
+	<string name="preference_info_privacy_policy">Privacy Policy</string>
+	<string name="preference_info_license">License</string>
+	<string name="preference_info_license_desc" translatable="false">GPL-3.0</string>
 	<string name="preference_info_libraries">Libraries</string>
 	<string name="preference_info_libraries_desc">A list of all used libraries</string>
 	<string name="preference_marker">Time indicator</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -446,6 +446,12 @@
 				android:key="preference_info_github"
 				android:title="@string/preference_info_github" />
 
+			<Preference
+				android:icon="@drawable/settings_info_github"
+				android:key="preference_info_license"
+				android:summary="@string/preference_info_license_desc"
+				android:title="@string/preference_info_license" />
+
 			<PreferenceScreen
 				android:icon="@drawable/settings_about_contributor"
 				android:key="preferences_contributors"


### PR DESCRIPTION
This PR updates the about page. It adds an entry with the license and more links.
Furthermore, it adds a dialog informing users that data has to be fetched from an external source to show the contributors. This is important regarding that some users may not want to transmit their data to GitHub.