### PR TITLE
Add color highlighting for subjects with homework

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -929,16 +929,14 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 				android.graphics.Color.parseColor(item.periodData.element.foreColor)
 
 			item.color = when {
-				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkColor
 				item.periodData.isExam() -> if (useDefault.contains("exam")) defaultColor else examColor
 				item.periodData.isCancelled() -> if (useDefault.contains("cancelled")) defaultColor else cancelledColor
 				item.periodData.isIrregular() -> if (useDefault.contains("irregular")) defaultColor else irregularColor
+				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkColor
 				else -> if (useDefault.contains("regular")) defaultColor else regularColor
 			}
 
 			item.pastColor = when {
-				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkPastColor
-
 				item.periodData.isExam() -> if (useDefault.contains("exam")) defaultColor.darken(
 					0.25f
 				) else examPastColor
@@ -950,6 +948,8 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 				item.periodData.isIrregular() -> if (useDefault.contains("irregular")) defaultColor.darken(
 					0.25f
 				) else irregularPastColor
+
+				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkPastColor
 
 				else -> if (useDefault.contains("regular")) defaultColor.darken(0.25f) else regularPastColor
 			}

--- a/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/MainActivity.kt
@@ -916,6 +916,8 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 		val examPastColor = weekViewPreferences.backgroundExamPast.value
 		val cancelledColor = weekViewPreferences.backgroundCancelled.value
 		val cancelledPastColor = weekViewPreferences.backgroundCancelledPast.value
+		val homeworkColor = weekViewPreferences.backgroundHomework.value
+		val homeworkPastColor = weekViewPreferences.backgroundHomeworkPast.value
 		val irregularColor = weekViewPreferences.backgroundIrregular.value
 		val irregularPastColor = weekViewPreferences.backgroundIrregularPast.value
 
@@ -927,6 +929,7 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 				android.graphics.Color.parseColor(item.periodData.element.foreColor)
 
 			item.color = when {
+				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkColor
 				item.periodData.isExam() -> if (useDefault.contains("exam")) defaultColor else examColor
 				item.periodData.isCancelled() -> if (useDefault.contains("cancelled")) defaultColor else cancelledColor
 				item.periodData.isIrregular() -> if (useDefault.contains("irregular")) defaultColor else irregularColor
@@ -934,6 +937,8 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 			}
 
 			item.pastColor = when {
+				item.periodData.element.homeWorks?.isNotEmpty() == true -> homeworkPastColor
+
 				item.periodData.isExam() -> if (useDefault.contains("exam")) defaultColor.darken(
 					0.25f
 				) else examPastColor
@@ -1165,6 +1170,8 @@ class NewMainAppState @OptIn(ExperimentalMaterial3Api::class) constructor(
 		var backgroundExamPast: State<Int>,
 		var backgroundCancelled: State<Int>,
 		var backgroundCancelledPast: State<Int>,
+		var backgroundHomework: State<Int>,
+		var backgroundHomeworkPast: State<Int>,
 		var backgroundIrregular: State<Int>,
 		var backgroundIrregularPast: State<Int>,
 		var weekLength: State<Int>,
@@ -2088,6 +2095,8 @@ fun rememberWeekViewPreferences(
 	backgroundExamPast: State<Int> = preferences.backgroundExamPast.getState(),
 	backgroundCancelled: State<Int> = preferences.backgroundCancelled.getState(),
 	backgroundCancelledPast: State<Int> = preferences.backgroundCancelledPast.getState(),
+	backgroundHomework: State<Int> = preferences.backgroundHomework.getState(),
+	backgroundHomeworkPast: State<Int> = preferences.backgroundHomeworkPast.getState(),
 	backgroundIrregular: State<Int> = preferences.backgroundIrregular.getState(),
 	backgroundIrregularPast: State<Int> = preferences.backgroundIrregularPast.getState(),
 	weekLength: State<Int> = preferences.weekCustomRange.getValueFlow()
@@ -2117,6 +2126,8 @@ fun rememberWeekViewPreferences(
 		backgroundExamPast = backgroundExamPast,
 		backgroundCancelled = backgroundCancelled,
 		backgroundCancelledPast = backgroundCancelledPast,
+		backgroundHomework = backgroundHomework,
+		backgroundHomeworkPast = backgroundHomeworkPast,
 		backgroundIrregular = backgroundIrregular,
 		backgroundIrregularPast = backgroundIrregularPast,
 		weekLength = weekLength,

--- a/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/sapuseven/untis/activities/SettingsActivity.kt
@@ -458,6 +458,26 @@ class SettingsActivity : BaseComposeActivity() {
 											)
 
 											ColorPreference(
+												title = { Text(stringResource(R.string.preference_background_homework)) },
+												dependency = dataStorePreferences.schoolBackground.with(
+													dependencyValue = { !it.contains("homework") }
+												),
+												dataStore = dataStorePreferences.backgroundHomework,
+												showAlphaSlider = true,
+												defaultValueLabel = stringResource(id = R.string.preferences_theme_color)
+											)
+
+											ColorPreference(
+												title = { Text(stringResource(R.string.preference_background_homework_past)) },
+												dependency = dataStorePreferences.schoolBackground.with(
+													dependencyValue = { !it.contains("homework") }
+												),
+												dataStore = dataStorePreferences.backgroundHomeworkPast,
+												showAlphaSlider = true,
+												defaultValueLabel = stringResource(id = R.string.preferences_theme_color)
+											)
+
+											ColorPreference(
 												title = { Text(stringResource(R.string.preference_background_irregular)) },
 												dependency = dataStorePreferences.schoolBackground.with(
 													dependencyValue = { !it.contains("irregular") }

--- a/app/src/main/java/com/sapuseven/untis/preferences/DataStorePreferences.kt
+++ b/app/src/main/java/com/sapuseven/untis/preferences/DataStorePreferences.kt
@@ -1,16 +1,20 @@
 package com.sapuseven.untis.preferences
 
+import android.graphics.Color
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.graphics.ColorUtils
+import androidx.core.graphics.toColor
 import com.sapuseven.untis.activities.BaseComposeActivity
 import com.sapuseven.untis.helpers.config.*
 import com.sapuseven.untis.ui.preferences.materialColors
 
 val BaseComposeActivity.dataStorePreferences: DataStorePreferences
-	@Composable
+	@RequiresApi(Build.VERSION_CODES.O) @Composable
 	get() = LocalContext.current.run {
 		DataStorePreferences(
 			doubleTapToExit = this.booleanDataStore(
@@ -106,6 +110,16 @@ val BaseComposeActivity.dataStorePreferences: DataStorePreferences
 				currentUserId(),
 				"preference_background_cancelled_past",
 				defaultValue = MaterialTheme.colorScheme.secondary.copy(alpha = .7f).toArgb()
+			),
+			backgroundHomework = this.intDataStore(
+				currentUserId(),
+				"preference_background_homework",
+				defaultValue = ColorUtils.blendARGB(MaterialTheme.colorScheme.primary.toArgb(), MaterialTheme.colorScheme.error.toArgb(), .7f).toColor().toArgb()
+			),
+			backgroundHomeworkPast = this.intDataStore(
+				currentUserId(),
+				"preference_background_homework_past",
+				defaultValue = ColorUtils.setAlphaComponent(ColorUtils.blendARGB(MaterialTheme.colorScheme.primary.toArgb(), MaterialTheme.colorScheme.error.toArgb(), .7f).toColor().toArgb(), 178)
 			),
 			themeColor = this.intDataStore(
 				currentUserId(),
@@ -270,6 +284,8 @@ class DataStorePreferences(
 	val backgroundIrregularPast: UntisPreferenceDataStore<Int>,
 	val backgroundCancelled: UntisPreferenceDataStore<Int>,
 	val backgroundCancelledPast: UntisPreferenceDataStore<Int>,
+	val backgroundHomework: UntisPreferenceDataStore<Int>,
+	val backgroundHomeworkPast: UntisPreferenceDataStore<Int>,
 	val themeColor: UntisPreferenceDataStore<Int>,
 	val darkTheme: UntisPreferenceDataStore<String>,
 	val darkThemeOled: UntisPreferenceDataStore<Boolean>,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -157,6 +157,8 @@
     <string name="preference_automute_minimum_break_length">Mindestpausendauer</string>
     <string name="preference_background_cancelled">Entfallene Stunden</string>
     <string name="preference_background_cancelled_past">Vergangene entfallene Stunden</string>
+    <string name="preference_background_homework">Stunden mit Hausaufgaben</string>
+    <string name="preference_background_homework_past">Vergangene Stunden mit Hausaufgaben</string>
     <string name="preference_background_exam">Stunden mit Tests</string>
     <string name="preference_background_exam_past">Vergangene Stunden mit Tests</string>
     <string name="preference_background_future">Hintergrundfarbe zukünftiger Tage</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,4 +116,5 @@
     <string name="infocenter_absence_unknown_reason">Causa desconocida</string>
     <string name="infocenter_timeformat_sameday">%2$s - %4$s, %1$s</string>
     <string name="infocenter_absences_filter_oldest_first">Primero el más antiguo</string>
+    <string name="preference_background_homework">Lecciones con deberes</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -244,6 +244,7 @@
     <string name="preference_background_irregular">Ezohiko eskolak</string>
     <string name="preference_background_cancelled_past">Iraganean bertan behera utzi diren eskolak</string>
     <string name="preference_background_exam_past">Iraganean azterketak izan dituzten eskolak</string>
+    <string name="preference_background_homework">Ikasgaiak etxeko lanekin</string>
     <string name="preference_background_exam">Azterketak dituzten eskolak</string>
     <string name="preference_background_cancelled">Bertan behera utzitako eskolak</string>
     <string name="preference_automute_enable_summary">Ez molestatu modua automatikoki aktibatzen du eskola orduetan</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,6 +122,7 @@
     <string name="preference_background_irregular">Cours irréguliers</string>
     <string name="preference_background_future">Arrière-plan pour journée à venir</string>
     <string name="preference_background_exam_past">Anciens cours avec un examen</string>
+    <string name="preference_background_homework">Cours avec devoirs</string>
     <string name="preference_background_exam">Cours avec un examen</string>
     <string name="preference_background_cancelled_past">Anciens cours annulés</string>
     <string name="preference_background_cancelled">Cours annulés</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -288,6 +288,7 @@
     <string name="preference_background_irregular">Izvanredna nastava</string>
     <string name="preference_background_future">Pozadina budućih dana</string>
     <string name="preference_background_exam_past">Prošla nastava s testovima</string>
+    <string name="preference_background_homework">숙제가 있는 코스</string>
     <string name="preference_background_exam">Nastava s testovima</string>
     <string name="preference_background_cancelled_past">Prošla otkazana nastava</string>
     <string name="preference_background_cancelled">Otkazana nastava</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -130,6 +130,7 @@
     <string name="preference_automute_cancelled_lessons">Forstum kansellerte skoletimer også</string>
     <string name="preference_background_cancelled">Kansellerte leksjoner</string>
     <string name="preference_background_cancelled_past">Tidligere kansellerte leksjoner</string>
+    <string name="preference_background_homework">Leksjoner med lekser</string>
     <string name="preference_background_exam">Leksjoner med prøver</string>
     <string name="preference_background_exam_past">Tidligere leksjoner med prøver</string>
     <string name="preference_background_future">Bakgrunn for fremtidig dager</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -76,4 +76,5 @@
     <string name="all_absences">Afwezigheden</string>
     <string name="all_homework">Huiswerk</string>
     <string name="errormessagedictionary_invalid_server_url">Ongeldige server URL!</string>
+    <string name="preference_background_homework">Cursussen met huiswerk</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -34,6 +34,7 @@
     <string name="login_please_log_in">Wybierz jedną z następujących opcji, aby się zalogować:</string>
     <string name="login_no_results">Brak wyników</string>
     <string name="login_search_by_school_name_or_address">Szukaj poprzez nazwę szkoły lub adres</string>
+    <string name="preference_background_homework">Lekcje z pracą domową</string>
     <string name="preference_timetable_hide_cancelled">Ukryj anulowane lekcje</string>
     <plurals name="roomfinder_item_desc">
         <item quantity="one">Ten Pokój jest wolny teraz.</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,7 @@
     <string name="activity_title_errors">Ошибки</string>
     <string name="all_dialog_datepicker_button_today">Сегодня</string>
     <string name="logindatainput_connecting">Соединение…</string>
+    <string name="preference_background_homework">Уроки с домашним заданием</string>
     <string name="preference_background_exam">Уроки с тестами</string>
     <string name="all_classes">Классы</string>
     <string name="all_no">Нет</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -44,6 +44,7 @@
     <string name="preference_background_irregular_past">Geçmiş düzensiz dersler</string>
     <string name="preference_background_irregular">Düzensiz dersler</string>
     <string name="preference_background_exam_past">Geçmiş testi bulunan dersler</string>
+    <string name="preference_background_homework">Ev ödevli dersler</string>
     <string name="preference_background_exam">Testi bulunan dersler</string>
     <string name="preference_background_cancelled_past">Geçmiş iptal edilen dersler</string>
     <string name="preference_background_cancelled">İptal edilen dersler</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -255,6 +255,7 @@
     <string name="preference_background_exam_past">考试课程（过期）</string>
     <string name="preference_background_irregular_past">不定期课程（过期）</string>
     <string name="preference_background_future">未来日期背景</string>
+    <string name="preference_background_homework">有家庭作业的课程</string>
     <string name="preference_background_exam">考试课程</string>
     <string name="preference_background_irregular">不定期课程</string>
     <string name="notifications_text_message_separator">"/ "</string>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -30,6 +30,8 @@
 	<integer name="preference_background_irregular_past_default">0xFF388E3C</integer>
 	<integer name="preference_background_cancelled_default">0xFF9E9E9E</integer>
 	<integer name="preference_background_cancelled_past_default">0xFF616161</integer>
+	<integer name="preference_background_homework_default">0xFFCD9E</integer>
+	<integer name="preference_background_homework_past_default">0xFFB661</integer>
 	<integer name="preference_background_future_default">0x00000000</integer>
 	<integer name="preference_background_past_default">0x40808080</integer>
 	<integer name="preference_marker_default">0xFFFFFFFF</integer>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,8 @@
     <string name="preference_automute_mute_priority">Don\'t allow priority events to ignore aute-mute</string>
     <string name="preference_background_cancelled">Cancelled lessons</string>
     <string name="preference_background_cancelled_past">Past cancelled lessons</string>
+    <string name="preference_background_homework">Lessons with homework</string>
+    <string name="preference_background_homework_past">Past lessons with homework</string>
     <string name="preference_background_exam">Lessons with tests</string>
     <string name="preference_background_exam_past">Past lessons with tests</string>
     <string name="preference_background_future">Future day background</string>


### PR DESCRIPTION
I added the color highlighting of subjects with homework, as suggested in Issue #404, implemented in first form.

This is my first commit to this project. Since I'm not that familiar with it yet, check my changes carefully.