### PR TITLE
Fixed irregular lesson color stuff

### DIFF
--- a/app/src/main/java/com/sapuseven/untis/mappers/TimetableMapper.kt
+++ b/app/src/main/java/com/sapuseven/untis/mappers/TimetableMapper.kt
@@ -53,11 +53,8 @@ class TimetableMapper @Inject constructor(
 			return preparePeriods(items, timetableHideCancelled)
 				.mapToEvents(
 					this,
-					contextType
-				)
-				.prepareEvents(
-					timetableSubstitutionsIrregular,
-					timetableBackgroundIrregular
+					contextType,
+					substitutionsIrregular = timetableSubstitutionsIrregular
 				)
 		}
 	}
@@ -68,12 +65,21 @@ class TimetableMapper @Inject constructor(
 		userSettings: UserSettings,
 		contextType: ElementType,
 		includeOrgIds: Boolean = true,
+		substitutionsIrregular: Boolean = false,
 	): List<Event<PeriodItem>> {
 		return map { period ->
 			val periodItem = PeriodItem(
 				masterDataRepository = masterDataRepository,
 				originalPeriod = period
 			)
+
+			if (substitutionsIrregular) {
+				periodItem.forceIrregular =
+					periodItem.classes.find { it.id != it.orgId } != null
+						|| periodItem.teachers.find { it.id != it.orgId } != null
+						|| periodItem.subjects.find { it.id != it.orgId } != null
+						|| periodItem.rooms.find { it.id != it.orgId } != null
+			}
 
 			Event(
 				title = periodItem.getShort(ElementType.SUBJECT),
@@ -145,32 +151,6 @@ class TimetableMapper @Inject constructor(
 		hideCancelled: Boolean,
 	): List<Period> = mapNotNull { item ->
 		if (hideCancelled && item.`is`(PeriodState.CANCELLED)) return@mapNotNull null
-		item
-	}
-
-	/**
-	 * Prepares the items for the timetable.
-	 *
-	 * This function marks items as irregular when they match certain rules
-	 *
-	 * @param substitutionsIrregular Whether items with substitutions should be marked as irregular
-	 * @param backgroundIrregular Whether irregular items should have a different background color
-	 * @return A list of prepared items
-	 */
-	private fun List<Event<PeriodItem>>.prepareEvents(
-		substitutionsIrregular: Boolean,
-		backgroundIrregular: Boolean
-	): List<Event<PeriodItem>> = mapNotNull { item ->
-		if (substitutionsIrregular) {
-			item.data?.apply {
-				forceIrregular =
-					classes.find { it.id != it.orgId } != null
-						|| teachers.find { it.id != it.orgId } != null
-						|| subjects.find { it.id != it.orgId } != null
-						|| rooms.find { it.id != it.orgId } != null
-				//TODO|| backgroundIrregular.getValue() && item.data.element.backColor != UNTIS_DEFAULT_COLOR
-			}
-		}
 		item
 	}
 

--- a/app/src/main/java/com/sapuseven/untis/ui/weekview/WeekViewEvent.kt
+++ b/app/src/main/java/com/sapuseven/untis/ui/weekview/WeekViewEvent.kt
@@ -53,8 +53,8 @@ sealed class EventStyle(
 		textStyleForScheme = {
 			textStyle ?: TextStyle(
 				color = if (
-					ColorUtils.calculateContrast(Color.Black.toArgb(), color.toArgb()) >
-					ColorUtils.calculateContrast(Color.White.toArgb(), color.toArgb())
+					ColorUtils.calculateContrast(Color.Black.toArgb(), color.compositeOverWhite().toArgb()) >
+					ColorUtils.calculateContrast(Color.White.toArgb(), color.compositeOverWhite().toArgb())
 				) Color.Black else Color.White
 			)
 		}
@@ -196,6 +196,17 @@ fun <T> WeekViewEvent(
 private fun CharSequence.asAnnotatedString(): AnnotatedString = let {
 	it as? AnnotatedString ?: AnnotatedString(it.toString())
 }
+
+/**
+ * Composites this color over a white background, giving back a fully opaque color.
+ * Required because ColorUtils.calculateContrast throws IllegalArgumentException if either color has alpha < 1.0 (is semi-transparent).
+ */
+private fun Color.compositeOverWhite() = Color(
+	red = red * alpha + (1f - alpha),
+	green = green * alpha + (1f - alpha),
+	blue = blue * alpha + (1f - alpha),
+	alpha = 1f
+)
 
 private fun LocalDateTime.seconds() = atZone(ZoneId.systemDefault()).toEpochSecond()
 


### PR DESCRIPTION
Those two issues should be fixed in this PR:

- Fixed #489: forceIrregular was set in prepareEvents() after getColorScheme() had already evaluated it, causing substitution based irregular lessons to always render with the regular color. Moved forceIrregular computation into mapToEvents() so it is set before getColorScheme() is called. Removed now unused method.

- Fixed #491: ColorUtils.calculateContrast() throws IllegalArgumentException when the background color has alpha < 255 (when the user sets the color slider to the middle). Added compositeOverWhite() extension to blend the color over white before passing it to calculateContrast(), so a fully opaque value is always used.

I tested it in the foss version on my samsung galaxy and it works there.
![tempFileForShare_20260414-133145](https://github.com/user-attachments/assets/6eee474a-c7bc-4cd0-b2da-18c934db2740)
