### PR TITLE
Fix getCacheFile

### DIFF
--- a/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
+++ b/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
@@ -58,8 +58,9 @@ class DiskCache<KeyType : Any, ValueType : Any>(
 	}
 
 	@OptIn(ExperimentalStdlibApi::class)
-	private fun getCacheFile(key: CacheKey<KeyType>): File {
-		val md = MessageDigest.getInstance("MD5")
-		return File(cacheDir, md.digest(key.toString().toByteArray()).toHexString())
-	}
+@OptIn(ExperimentalStdlibApi::class)
+private fun getCacheFile(key: CacheKey<KeyType>): File {
+    val md = MessageDigest.getInstance("SHA-256")
+    return File(cacheDir, md.digest(key.toString().toByteArray()).toHexString())
+}
 }


### PR DESCRIPTION
## Analysis context

| Property | Value |
|---|---|
| Method | `getCacheFile` |
| Class | `com.sapuseven.untis.data.cache.DiskCache` |
| File | `core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt` |
| Specification | `MessageDigestSpec` |
| Analysis tool | `droidbot:bfs_greedy` |

## Proposed change

The MD5 digest is used solely as a derived filename for disposable cache entries. Replacing it with SHA-256 satisfies the allowed algorithm set; existing MD5-named cache files become cache misses and can be regenerated under the authorized cache-invalidation policy.

## Compatibility note

This change updates an identifier used only for derived, regenerable cache entries. Existing entries created with the previous identifier may become cache misses and be regenerated. The change is not intended to invalidate user-owned source data, credentials, preferences, or offline-only data. Legacy cache files may remain until the project's normal cache cleanup.

## Validation

- [x] Change limited to the related file
- [x] Manual review required
- [ ] Confirmed by a project maintainer

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.

## Repository guidance

This contribution was prepared with reference to:

- `README.md`