### PR TITLE
Fix getCacheFile

### DIFF
--- a/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
+++ b/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
@@ -58,7 +58,6 @@ class DiskCache<KeyType : Any, ValueType : Any>(
 	}
 
 	@OptIn(ExperimentalStdlibApi::class)
-	@OptIn(ExperimentalStdlibApi::class)
 	private fun getCacheFile(key: CacheKey<KeyType>): File {
 		val md = MessageDigest.getInstance("SHA-256")
 		return File(cacheDir, "sha256-v1-" + md.digest(key.toString().toByteArray()).toHexString())

--- a/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
+++ b/core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt
@@ -58,8 +58,9 @@ class DiskCache<KeyType : Any, ValueType : Any>(
 	}
 
 	@OptIn(ExperimentalStdlibApi::class)
+	@OptIn(ExperimentalStdlibApi::class)
 	private fun getCacheFile(key: CacheKey<KeyType>): File {
-		val md = MessageDigest.getInstance("MD5")
-		return File(cacheDir, md.digest(key.toString().toByteArray()).toHexString())
+		val md = MessageDigest.getInstance("SHA-256")
+		return File(cacheDir, "sha256-v1-" + md.digest(key.toString().toByteArray()).toHexString())
 	}
 }


### PR DESCRIPTION
## Analysis context

| Property | Value |
|---|---|
| Method | `getCacheFile` |
| Class | `com.sapuseven.untis.data.cache.DiskCache` |
| File | `core/data/src/main/kotlin/com/sapuseven/untis/core/data/cache/DiskCache.kt` |
| Specification | `MessageDigestSpec` |
| Analysis tool | `droidbot:bfs_greedy` |

## Proposed change

Replacing `MD5` with the standard `SHA-256` algorithm satisfies the allowed MessageDigest algorithm set while retaining provider selection through `MessageDigest.getInstance(String)`. Prefixing the generated filename with a SHA-256 version namespace prevents collisions with legacy MD5-derived cache entries; those entries become authorized cache misses and are regenerated through the existing `put` path.

## Compatibility note

This change updates an identifier used only for derived, regenerable cache entries. Existing entries created with the previous identifier may become cache misses and be regenerated. The change is not intended to invalidate user-owned source data, credentials, preferences, or offline-only data. Legacy cache files may remain until the project's normal cache cleanup.

## Validation

- [x] Change limited to the related file
- [x] Manual review required
- [ ] Confirmed by a project maintainer

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.

## Repository guidance

This contribution was prepared with reference to:

- `README.md`